### PR TITLE
i18n example

### DIFF
--- a/app.html
+++ b/app.html
@@ -28,6 +28,7 @@
 	<meta name="author" content="Team Virufy">
 
 	<link rel="stylesheet" href="assets/css/main.css" />
+	<link rel="stylesheet" href="assets/css/header.css" />
 		<script src="https://kit.fontawesome.com/828decba15.js" crossorigin="anonymous"></script>
 
 	<!--Sweet Alert-->
@@ -60,18 +61,27 @@
 				<img src="images/logo.png">
 			</a>
 			<nav id="nav">
-				<a href="index.html">Home</a>
-				<a href="./index.html#about">About</a>
-				<a href="./app.html">App</a>
-				<a href="./research.html">Research</a>
-				<a href="data.html">Open Data</a>
-				<a href="./team.html">Team</a>
-				<a href="./goals.html">Goals</a>
-				<a href="./join.html">Join Us</a>
-				<a href="./oyw.html">One Young World</a>
-				<a href="https://blog.virufy.org/">Blog</a>
-				<a href="https://www.gofundme.com/f/virufyorg" target="_blank"><button>Donate</button>
+				<a href="index.html" data-i18n="nav.home"></a>
+				<a href="./index.html#about" data-i18n="nav.about"></a>
+				<a href="./app.html" data-i18n="nav.app"></a>
+				<a href="./research.html" data-i18n="nav.research"></a>
+				<a href="data.html" data-i18n="nav.openData"></a>
+				<a href="./team.html" data-i18n="nav.team"></a>
+				<a href="./goals.html" data-i18n="nav.goals"></a>
+				<a href="./join.html" data-i18n="nav.joinUs"></a>
+				<a href="./oyw.html" data-i18n="nav.oneYoungWorld"></a>
+				<a href="https://blog.virufy.org/"　data-i18n="nav.blog"></a>
+				<a href="https://www.gofundme.com/f/virufyorg" target="_blank">
+					<button data-i18n="nav.donate"></button>
 				</a>
+
+				<div class="language-toggle">
+					<select id="language-toggle-select" name="language" id="language">
+						<option
+						 value="en" data-i18n="languageToggle.en"></option>
+						<option value="jp" data-i18n="languageToggle.jp"></option>
+					</select>
+				</div>
 			</nav>
 			<a href="#navPanel" class="navPanelToggle"><span class="fa fa-bars"></span></a>
 		</div>
@@ -81,7 +91,7 @@
 	<section id="app-banner">
 		<div class="inner">
 			<header>
-				<h1>Virufy COVID-19 (Beta)</h1>
+				<h1 data-i18n="appBanner.title"></h1>
 			</header>
 		</div>
 	</section>
@@ -437,8 +447,14 @@
 	<script src="assets/js/util.js"></script>
 	<script src="assets/js/main.js"></script>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-sweetalert/1.0.1/sweetalert.js"></script>
+	<!-- internationalization -->
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/i18next/8.1.0/i18next.min.js" ></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-i18next/1.2.0/jquery-i18next.min.js" ></script>
+	<script src="https://unpkg.com/i18next-xhr-backend/i18nextXHRBackend.js"></script>
+	<script src="https://unpkg.com/i18next-browser-languagedetector/i18nextBrowserLanguageDetector.js"></script>
+	<script src="https://cdn.rawgit.com/mattdiamond/Recorderjs/08e7abd9/dist/recorder.js"></script>
+	<script src="assets/js/i18n.js"></script>
 	<script>
-
         $('#sym-checkbox-wrapper .sym-checkbox').on('change', function () {
             let $this = $(this);
             if ($this.prop('checked')) {
@@ -450,68 +466,67 @@
             }
         });
 
+		const sleep = async (msec) => new Promise((resolve) => setTimeout(resolve, msec));
 
-        const sleep = async (msec) => new Promise((resolve) => setTimeout(resolve, msec));
-
-function resetUserID () {
-	localStorage.removeItem("virufy-userid");
-	//alert("reset userid");
-	localStorage.removeItem("virufy-age");
-};
-function initFormData () {
-	if (localStorage.getItem("virufy-age")) {
-		age.value = localStorage.getItem("virufy-age");
-	}
-};
-
-//resetbtn.onclick = () => resetUserID();
-window.onload = () => {
-	initFormData();
-};
-
-async function uploadAudio () {
-  for (;;) {
-    try {
-			// const url = "http://localhost:8899/";
-			const url = "https://voice.sabae.cc/";
-			const formdata = new FormData(myForm)
-			if (blob_arr_count.length>0){
-				formdata.append("count_audio", blob_arr_count[0], "count.wav");
+		function resetUserID () {
+			localStorage.removeItem("virufy-userid");
+			//alert("reset userid");
+			localStorage.removeItem("virufy-age");
+		};
+		function initFormData () {
+			if (localStorage.getItem("virufy-age")) {
+				age.value = localStorage.getItem("virufy-age");
 			}
-			if (blob_arr.length > 0) {
-				formdata.append("cough_audio", blob_arr[0], "cough.wav");
-			}
+		};
 
-			if (age.value != localStorage.getItem("virufy-age")) {
-				 resetUserID();
-			}
-			let userid = localStorage.getItem("virufy-userid");
-			if (!userid) {
-				userid = Math.random().toString() + "-" + new Date().getTime();
-				formdata.append("userid", userid);
-				localStorage.setItem("virufy-userid", userid);
-			} else {
-				formdata.append("userid", userid);
-			}
+		//resetbtn.onclick = () => resetUserID();
+		window.onload = () => {
+			initFormData();
+		};
 
-			// save the value of Age
-			if (!localStorage.getItem("virufy-age")){
-				localStorage.setItem("virufy-age", age.value);
-			}
+		async function uploadAudio () {
+		for (;;) {
+			try {
+					// const url = "http://localhost:8899/";
+					const url = "https://voice.sabae.cc/";
+					const formdata = new FormData(myForm)
+					if (blob_arr_count.length>0){
+						formdata.append("count_audio", blob_arr_count[0], "count.wav");
+					}
+					if (blob_arr.length > 0) {
+						formdata.append("cough_audio", blob_arr[0], "cough.wav");
+					}
 
-      const res = await (await fetch(url, { method: 'POST', body: formdata })).json()
-      console.log(res)
-      if (res.res == 'ok') {
-        return res.id
-      }
-			alert("upload error, retry? (" + res.res + ") tap to retry");
-    } catch (e) {
-			alert("upload error, retry? (" + e + ") tap to retry");
-			break;
-    }
-		await sleep(500);
-  }
-}
+					if (age.value != localStorage.getItem("virufy-age")) {
+						resetUserID();
+					}
+					let userid = localStorage.getItem("virufy-userid");
+					if (!userid) {
+						userid = Math.random().toString() + "-" + new Date().getTime();
+						formdata.append("userid", userid);
+						localStorage.setItem("virufy-userid", userid);
+					} else {
+						formdata.append("userid", userid);
+					}
+
+					// save the value of Age
+					if (!localStorage.getItem("virufy-age")){
+						localStorage.setItem("virufy-age", age.value);
+					}
+
+			const res = await (await fetch(url, { method: 'POST', body: formdata })).json()
+			console.log(res)
+			if (res.res == 'ok') {
+				return res.id
+			}
+					alert("upload error, retry? (" + res.res + ") tap to retry");
+			} catch (e) {
+					alert("upload error, retry? (" + e + ") tap to retry");
+					break;
+			}
+				await sleep(500);
+		}
+		}
 
 		async function submit_data() {
 			await uploadAudio();
@@ -545,8 +560,13 @@ async function uploadAudio () {
 
 	</script>
 
+	<script>
+		i18nManager(function() {
+			$('body').localize();
+		})
+	</script>
+
 	<!-- inserting these scripts at the end to be able to use all the elements in the DOM -->
-	<script src="https://cdn.rawgit.com/mattdiamond/Recorderjs/08e7abd9/dist/recorder.js"></script>
 	<script src="assets/js/app.js"></script>
 </body>
 

--- a/assets/css/header.css
+++ b/assets/css/header.css
@@ -1,0 +1,4 @@
+#header .language-toggle {
+    float: right;
+    display: block;
+}

--- a/assets/js/i18n.js
+++ b/assets/js/i18n.js
@@ -1,0 +1,30 @@
+var i18nManager = function(updateContent) {
+    i18next
+        .use(i18nextXHRBackend)
+        .use(i18nextBrowserLanguageDetector)
+        .init({
+            fallbackLng: 'en',
+            debug: true,
+            backend: {
+            loadPath: 'locales/{{lng}}/{{ns}}.json',
+            crossDomain: false
+            }
+        }, function(err, t) {
+            jqueryI18next.init(i18next, $);
+            updateLanguageToggleSelectOnLoad();          
+            updateContent();
+            
+            i18next.on('languageChanged', () => {
+                updateContent();
+            });
+        });
+}
+
+$('#language-toggle-select').on('change', function() {
+    let language = this.value;
+    i18next.changeLanguage(language);
+})
+
+function updateLanguageToggleSelectOnLoad() {
+    $('#language-toggle-select').val(i18next.language);
+}

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -1,0 +1,22 @@
+{
+    "nav": {
+        "home": "Home",
+        "about": "About",
+        "app": "App",
+        "research": "Research",
+        "openData": "Open Data",
+        "team": "Team",
+        "goals": "Goals",
+        "joinUs": "Join Us",
+        "oneYoungWorld": "One Young World",
+        "blog": "Blog",
+        "donate": "DONATE"
+    },
+    "languageToggle": {
+        "en": "English",
+        "jp": "Japanese"
+    },
+    "appBanner": {
+        "title": "Virufy COVID-19 (Beta)"
+    }
+}

--- a/locales/jp/translation.json
+++ b/locales/jp/translation.json
@@ -1,0 +1,22 @@
+{
+    "nav": {
+        "home": "ホーム",
+        "about": "Virufyとは？",
+        "app": "アプリ",
+        "research": "研究",
+        "openData": "オープンデータ",
+        "team": "チーム",
+        "goals": "目的",
+        "joinUs": "チームに参加",
+        "oneYoungWorld": "One Young World",
+        "blog": "ブログ",
+        "donate": "寄付"
+    },
+    "languageToggle": {
+        "en": "英語",
+        "jp": "日本語"
+    },
+    "appBanner": {
+        "title": "Virufy COVID-19 (β版)"
+    }
+}


### PR DESCRIPTION
I added i18next which is a library for handling internationalization. 

Each language has its own json file in the locales folder. For example english is in locales/en/translation.json
i18n looks for a file of this name in a directory matching the name of the language. You can even define something more specific, for example en-US for US english. If that doesn't exist, it will fall back to 'en'. The naming convention follows ISO standard naming for languages.

In order to load this file, it uses XHR and requires cross domain requests, so when you are editing on local, you will need to host on localhost in order for it to work. I used an app called CodeKit to do this locally since I didn't see anything for setting up a dev environment inside this git. 

For the purposes of this example I just added the needed libraries from cdn links, and only on the app.html page. Really this should be defined in a way so that it is shared across all the pages to reduce duplication.

I added some translations for the navigation and header title so you could see how this system works.

I made a new file for i18n that will talk to i18n directly. To activate it via jquery for a specific page, I call this:

`<script>
		i18nManager(function() {
			$('body').localize();
		})
	</script>`

To add a string to an element, add `data-i18n="key"` to the html element, where key is the key path in the translations.json.

You can choose where on the page to apply localization too. We want the whole page, so I set it to body. This passes this function to the i18n library and runs those changes whenever the language changes. You could also run this code inside the i18n js file, and it would apply to the body tag of any page that includes this js file.

i18next also detects the language from the browser on load, and uses that by default if translations exist.

For more info on i18next: https://www.i18next.com/
I am also using a jquery plugin for i18next which lets you have the attributes on html tags.