### PR TITLE
Added Candid Seal

### DIFF
--- a/app/[lang]/components/footer/NonProfitDisclaimers.jsx
+++ b/app/[lang]/components/footer/NonProfitDisclaimers.jsx
@@ -3,6 +3,9 @@ import Text from '../Text';
 export default function NonProfitDisclaimers({nonProfitSection}) {
     return (
         <>
+        <a href="https://www.guidestar.org/profile/shared/f0cf98a8-3b5a-495f-86c0-d2d58564086c" target="_blank" className="block mt-4">
+          <img src="https://widgets.guidestar.org/TransparencySeal/10153729" alt="GuideStar Profile" className="mx-auto" />
+        </a>
         <div className="align-center mt-10 flex w-full flex-col gap-7 text-white lg:hidden">
             <div className="align-center m-auto max-w-4xl text-center text-[25px]">
               <Text Text={nonProfitSection.title} Style="" TextClassProps="" />


### PR DESCRIPTION
Jira Ticket Description:

Share your Seal on your website

You can now place the Candid Seal of Transparency on your website to demonstrate your ongoing commitment. The Seal links directly to your profile on GuideStar so your supporters can easily see your information and verify your accomplishment.
Displaying the Seal on your website is easy:

Select and copy the HTML code below

Paste the code into your webpage editor or ask your webmaster for help.

That’s it! Your website will automatically reflect your current Seal. This means your supporters will always see your latest Seal with no additional work for you!
By using this code you're agreeing to our [terms and conditions](https://learn.guidestar.org/update-nonprofit-report/resources/guidestar-exchange-terms-of-use). (edited) 

 [CANDID: Virufy Profile for Non-Profit](https://docs.google.com/document/d/1KHgGkJ3bEZPSWTx9KXf442PLWEK7aEGgQxCHv1TL-wI/edit?disco=AAABbM6fjr0)