### PR TITLE
Minor fixes

### DIFF
--- a/app/i18n/ar/news.ts
+++ b/app/i18n/ar/news.ts
@@ -96,7 +96,7 @@ const pressReleases: PressReleases = {
     {
       title: 'ورشة عمل أصوات COVID-19',
       date: '2020',
-      subText: 'One Young World',
+      subText: '',
       url: 'https://health-sounds.cl.cam.ac.uk/workshop20/short-talks.html',
       linkText: 'اقرأ المزيد',
     },

--- a/app/i18n/ar/oneYoungWorld.ts
+++ b/app/i18n/ar/oneYoungWorld.ts
@@ -19,7 +19,7 @@ const oneYoungWorld: OneYoungWorld = {
   },
   navbarTexts: {
     oyw: 'One Young World',
-    teamLeads: 'قادة الفريق',
+    teamLeads: 'سفراء الفريق',
   },
   oyw: {
     bgImage: BgBody,

--- a/app/i18n/ar/teamLeads.ts
+++ b/app/i18n/ar/teamLeads.ts
@@ -22,7 +22,7 @@ import {
 import { type TeamLeadsType } from '../types/teamLeads';
 
 const teamLeads: TeamLeadsType = {
-  title: 'OYW قادة الفريق',
+  title: 'OYW السفراء',
   cards: [
     {
       name: 'أميل خانزادا',

--- a/app/i18n/en/news.ts
+++ b/app/i18n/en/news.ts
@@ -100,7 +100,7 @@ const pressReleases: PressReleases = {
     {
       title: 'Sounds of COVID-19 Workshop',
       date: '2020',
-      subText: 'One Young World',
+      subText: '',
       url: 'https://health-sounds.cl.cam.ac.uk/workshop20/short-talks.html',
       linkText: 'Read More',
     },

--- a/app/i18n/en/oneYoungWorld.ts
+++ b/app/i18n/en/oneYoungWorld.ts
@@ -19,7 +19,7 @@ const oneYoungWorld: OneYoungWorld = {
   },
   navbarTexts: {
     oyw: 'One Young World',
-    teamLeads: 'Team Leads',
+    teamLeads: 'Team Ambassadors',
   },
   oyw: {
     bgImage: BgBody,

--- a/app/i18n/en/teamLeads.ts
+++ b/app/i18n/en/teamLeads.ts
@@ -22,7 +22,7 @@ import {
 import { type TeamLeadsType } from '../types/teamLeads';
 
 const teamLeads: TeamLeadsType = {
-  title: 'OYW Team Leads',
+  title: 'OYW Ambassadors',
   cards: [
     {
       name: 'Amil Khanzada',
@@ -135,7 +135,7 @@ const teamLeads: TeamLeadsType = {
     },
     {
       name: 'Allana Doyle',
-      texts: ['Embajador OYW, EE.UU11'],
+      texts: ['Ambassador OYW, EE.UU11'],
       image: Allana,
       altText: 'image of Allana Doyle',
     },

--- a/app/i18n/es/news.ts
+++ b/app/i18n/es/news.ts
@@ -100,7 +100,7 @@ const pressReleases: PressReleases = {
     {
       title: 'Sounds of COVID-19 Workshop',
       date: '2020',
-      subText: 'One Young World',
+      subText: '',
       url: 'https://health-sounds.cl.cam.ac.uk/workshop20/short-talks.html',
       linkText: 'Read More',
     },

--- a/app/i18n/es/oneYoungWorld.ts
+++ b/app/i18n/es/oneYoungWorld.ts
@@ -19,7 +19,7 @@ const oneYoungWorld: OneYoungWorld = {
   },
   navbarTexts: {
     oyw: 'One Young World',
-    teamLeads: 'Team Leads',
+    teamLeads: 'Team Ambassadors',
   },
   oyw: {
     bgImage: BgBody,

--- a/app/i18n/es/teamLeads.ts
+++ b/app/i18n/es/teamLeads.ts
@@ -22,7 +22,7 @@ import {
 import { type TeamLeadsType } from '../types/teamLeads';
 
 const teamLeads: TeamLeadsType = {
-  title: 'OYW Team Leads',
+  title: 'OYW Ambassadors',
   cards: [
     {
       name: 'Amil Khanzada',
@@ -135,7 +135,7 @@ const teamLeads: TeamLeadsType = {
     },
     {
       name: 'Allana Doyle',
-      texts: ['Embajador OYW, EE.UU11'],
+      texts: ['Ambassador OYW, EE.UU11'],
       image: Allana,
       altText: 'image of Allana Doyle',
     },

--- a/app/i18n/ja/news.ts
+++ b/app/i18n/ja/news.ts
@@ -97,7 +97,7 @@ const pressReleases: PressReleases = {
     {
       title: 'COVID-19の音に関するワークショップ',
       date: '2020年',
-      subText: 'One Young World',
+      subText: '',
       url: 'https://health-sounds.cl.cam.ac.uk/workshop20/short-talks.html',
       linkText: '続きを読む',
     },

--- a/app/i18n/ja/oneYoungWorld.ts
+++ b/app/i18n/ja/oneYoungWorld.ts
@@ -19,7 +19,7 @@ const oneYoungWorld: OneYoungWorld = {
   },
   navbarTexts: {
     oyw: 'One Young World',
-    teamLeads: 'チームリーダー',
+    teamLeads: 'チームアンバサダー',
   },
   oyw: {
     bgImage: BgBody,

--- a/app/i18n/ja/teamLeads.ts
+++ b/app/i18n/ja/teamLeads.ts
@@ -22,7 +22,7 @@ import {
 import { type TeamLeadsType } from '../types/teamLeads';
 
 const teamLeads: TeamLeadsType = {
-  title: 'OYWチームリーダー',
+  title: 'OYWアンバサダー',
   cards: [
     {
       name: 'アミル・カンザダ',


### PR DESCRIPTION
1. Updated OYW Team Leads - OYW Ambassadors in EN/ES lang.
2. For Allana Doyle updated her title - Embajador OYW, EE.UU11 to Ambassador OYW, EE.UU11 in EN/ES lang.
3. Changed OYW Team Leads to OYW Team Ambassadors in all 4 languages.
4. Changed Team Leads Tab to Team Ambassadors in all 4 languages.
5. Removed - "One Young World" subtext for "Sounds of COVID-19 Workshop" in News Tab in all lang.