### PR TITLE
Fixing Virumap slides and msg pages

### DIFF
--- a/app/[lang]/virumap-msg-jp/page.tsx
+++ b/app/[lang]/virumap-msg-jp/page.tsx
@@ -1,0 +1,13 @@
+'use client';
+import { useEffect } from 'react';
+
+const paperURL =
+  'https://docs.google.com/document/d/1HLQ7ZNMR1wO3BdaWnfQw3_yyhBfNBJGYz8zWN25gA8o/edit?usp=sharing';
+
+export default function VirumapMsgJPRedirect() {
+  useEffect(() => {
+    window.location.replace(paperURL);
+  }, []);
+
+  return <p>Redirecting to Japanese message document...</p>;
+}

--- a/app/[lang]/virumap-msg/page.tsx
+++ b/app/[lang]/virumap-msg/page.tsx
@@ -1,13 +1,13 @@
-import { type Locale } from '@/i18n-config';
-import RedirectWithSpinner from '../components/RedirectWithSpinner';
+'use client';
+import { useEffect } from 'react';
 
-const VirumapMsgPage = ({ params: { lang } }: { params: { lang: Locale } }) => {
-  const targetUrl =
-    lang === 'ja'
-      ? 'https://tiny.cc/virumap-msg-jp'
-      : 'https://tiny.cc/virumap-msg';
+const paperURL =
+  'https://docs.google.com/document/d/1e6p9TAd5NC4W7Lp58oxIp3FhUDGMexXXPL-f4--hhKk/edit?usp=sharing';
 
-  return <RedirectWithSpinner targetUrl={targetUrl} />;
-};
+export default function VirumapMsgRedirect() {
+  useEffect(() => {
+    window.location.replace(paperURL);
+  }, []);
 
-export default VirumapMsgPage;
+  return <p>Redirecting to English message document...</p>;
+}

--- a/app/[lang]/virumap-slide-jp/page.tsx
+++ b/app/[lang]/virumap-slide-jp/page.tsx
@@ -1,0 +1,13 @@
+'use client';
+import { useEffect } from 'react';
+
+const paperURL =
+  'https://docs.google.com/presentation/d/1GqNirFzOrWsLoLaH5hSe8YVXTMMrWZ1gW5d56jICs30/edit?usp=sharing';
+
+export default function VirumapSlideJPRedirect() {
+  useEffect(() => {
+    window.location.replace(paperURL);
+  }, []);
+
+  return <p>Redirecting to Japanese slide deck...</p>;
+}

--- a/app/[lang]/virumap-slides/page.tsx
+++ b/app/[lang]/virumap-slides/page.tsx
@@ -1,17 +1,13 @@
-import { type Locale } from '@/i18n-config';
-import RedirectWithSpinner from '../components/RedirectWithSpinner';
+'use client';
+import { useEffect } from 'react';
 
-const VirumapSlidesPage = ({
-  params: { lang },
-}: {
-  params: { lang: Locale };
-}) => {
-  const targetUrl =
-    lang === 'ja'
-      ? 'https://tiny.cc/virumap-slide-jp'
-      : 'https://tiny.cc/virumap-slides';
+const paperURL =
+  'https://docs.google.com/presentation/d/1Sb3WXxKrJPbdKkKH9IXV4iWCd3b5iSz5f_92UuJbYZc/edit?usp=sharing';
 
-  return <RedirectWithSpinner targetUrl={targetUrl} />;
-};
+export default function VirumapSlidesRedirect() {
+  useEffect(() => {
+    window.location.replace(paperURL);
+  }, []);
 
-export default VirumapSlidesPage;
+  return <p>Redirecting to English slide deck...</p>;
+}

--- a/app/virumap-msg-jp/page.tsx
+++ b/app/virumap-msg-jp/page.tsx
@@ -1,0 +1,12 @@
+'use client';
+import { useEffect } from 'react';
+
+const VirumapMsgJPRedirect = () => {
+  useEffect(() => {
+    window.location.href = '/ja/virumap-msg-jp';
+  }, []);
+
+  return <p>Redirecting to Japanese message...</p>;
+};
+
+export default VirumapMsgJPRedirect;

--- a/app/virumap-msg/page.tsx
+++ b/app/virumap-msg/page.tsx
@@ -1,0 +1,12 @@
+'use client';
+import { useEffect } from 'react';
+
+const VirumapMsgRedirect = () => {
+  useEffect(() => {
+    window.location.href = '/en/virumap-msg';
+  }, []);
+
+  return <p>Redirecting to message...</p>;
+};
+
+export default VirumapMsgRedirect;

--- a/app/virumap-slide-jp/page.tsx
+++ b/app/virumap-slide-jp/page.tsx
@@ -1,0 +1,12 @@
+'use client';
+import { useEffect } from 'react';
+
+const VirumapSlidesJPRedirect = () => {
+  useEffect(() => {
+    window.location.href = '/ja/virumap-slide-jp';
+  }, []);
+
+  return <p>Redirecting to Japanese slides...</p>;
+};
+
+export default VirumapSlidesJPRedirect;

--- a/app/virumap-slides/page.tsx
+++ b/app/virumap-slides/page.tsx
@@ -1,0 +1,12 @@
+'use client';
+import { useEffect } from 'react';
+
+const VirumapSlidesRedirect = () => {
+  useEffect(() => {
+    window.location.href = '/en/virumap-slides';
+  }, []);
+
+  return <p>Redirecting to slides...</p>;
+};
+
+export default VirumapSlidesRedirect;


### PR DESCRIPTION
1. New localized redirect pages

      app/[lang]/virumap-msg-jp/page.tsx → Redirects to Japanese message doc

      app/[lang]/virumap-slide-jp/page.tsx → Redirects to Japanese slide deck

2. Refactored existing localized pages

      Replaced TinyURL-based redirection with direct Google Docs/Slides URLs in:

          app/[lang]/virumap-msg/page.tsx → now redirects to English message doc

          app/[lang]/virumap-slides/page.tsx → now redirects to English slide deck

3. Added legacy support routes (non-localized redirects):

       /virumap-msg → redirects to /en/virumap-msg

       /virumap-msg-jp → redirects to /ja/virumap-msg-jp

       /virumap-slides → redirects to /en/virumap-slides

       /virumap-slide-jp → redirects to /ja/virumap-slide-jp