### PR TITLE
Fix Message Us button external to LinkedIn redirect

### DIFF
--- a/app/[lang]/components/ActionBanner.tsx
+++ b/app/[lang]/components/ActionBanner.tsx
@@ -1,19 +1,14 @@
-import { type Locale } from '@/i18n-config';
-import Link from 'next/link';
-
 import { ColorProps, TextSizeProps } from '../themes';
 
 const ActionBanner = ({
   title,
   text,
   buttonText,
-  lang,
   page,
 }: {
   title: string;
   text: string;
   buttonText: string;
-  lang: Locale;
   page: string;
 }) => {
   return (
@@ -33,11 +28,14 @@ const ActionBanner = ({
             {text}
           </p>
         </div>
-        <button
-          className={`mt-10 whitespace-nowrap rounded-full px-6 py-3 ${TextSizeProps.p} ${ColorProps.bgGradientReverse}`}
+        <a
+          href={page}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={`mt-10 inline-block whitespace-nowrap rounded-full px-6 py-3 text-white ${TextSizeProps.p} ${ColorProps.bgGradientReverse}`}
         >
-          <Link href={`/${lang}${page}`}>{buttonText}</Link>
-        </button>
+          {buttonText}
+        </a>
       </div>
     </section>
   );

--- a/app/[lang]/sevenai/AiClient.tsx
+++ b/app/[lang]/sevenai/AiClient.tsx
@@ -121,7 +121,7 @@ export default function AiPage({
           </div>
         </section>
       </div>
-      <ActionBanner title={banner.title} text={banner.text} buttonText={banner.buttonText} lang={lang} page={banner.url}/>
+      <ActionBanner title={banner.title} text={banner.text} buttonText={banner.buttonText} page={banner.url}/>
     </div>
   );
 }

--- a/app/[lang]/sevensupporters/page.tsx
+++ b/app/[lang]/sevensupporters/page.tsx
@@ -91,7 +91,6 @@ const SevenSupporters = ({
           title={banner.title}
           text={banner.text[0]}
           buttonText={banner.buttontext}
-          lang={lang}
           page={banner.link}
         />
       </section>

--- a/app/[lang]/sevenwho-we-are/page.tsx
+++ b/app/[lang]/sevenwho-we-are/page.tsx
@@ -189,7 +189,6 @@ const SevenSupporters = ({
           title={banner.title}
           text={banner.text[0]}
           buttonText={banner.buttontext}
-          lang={lang}
           page={banner.link}
         />
       </section>

--- a/app/i18n/en/sevenwho-we-are.ts
+++ b/app/i18n/en/sevenwho-we-are.ts
@@ -71,7 +71,7 @@ const sevenwhoweare: sevenwho_we_are = {
     text: [
       'Whether you want to volunteer, partner with us, or support our mission, we’d love to hear from you and explore how we can work together to make a meaningful impact.',
     ],
-    link: '',
+    link: 'https://www.linkedin.com/company/virufy/posts/?feedView=all',
   },
 };
 export default sevenwhoweare;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2322,7 +2322,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -16860,6 +16859,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
- Updated the Message Us CTA to redirect to Virufy’s LinkedIn page
- Fixed ActionBanner to correctly handle external links without prefixing locale (e.g., /en)
- Verified locally and confirmed build succeeds (npm run build)